### PR TITLE
Install requirements and dev-requirements directly

### DIFF
--- a/singleuser/Dockerfile
+++ b/singleuser/Dockerfile
@@ -34,22 +34,9 @@ RUN mkdir -p /srv/pwb
 
 RUN git clone --recursive https://gerrit.wikimedia.org/r/pywikibot/core.git /srv/pwb
 ADD user-config.py /srv/pwb/
+ADD install-pwb /usr/local/bin
 
-RUN virtualenv -p python3 /srv/pwb
-
-RUN /srv/pwb/bin/pip install \
-    requests \
-    python-stdnum \
-    mwoauth \
-    google \
-    socketIO-client \
-    flickrapi \
-    irc \
-    mwparserfromhell \
-    beautifulsoup4 \
-    pycountry \
-    memento_client \
-    ipywidgets
+RUN /usr/local/bin/install-pwb
 
 # MW related libraries
 RUN /srv/pwb/bin/pip install \

--- a/singleuser/install-pwb
+++ b/singleuser/install-pwb
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+virtualenv -p python3 /srv/pwb
+
+# Upgrade pip to support conditionals in requirements.txt
+/srv/pwb/bin/pip install -U pip
+
+# Remove 'Pillow' from requirements.txt
+sed -e '/Pillow/d' /srv/pwb/requirements.txt > /tmp/requirements.txt
+
+/srv/pwb/bin/pip install -r /tmp/requirements.txt
+/srv/pwb/bin/pip install -r /srv/pwb/dev-requirements.txt
+
+# cleanup
+rm /tmp/requirements.txt

--- a/singleuser/user-config.py
+++ b/singleuser/user-config.py
@@ -6,7 +6,7 @@ family = 'wikipedia'
 
 custom_path = os.path.expanduser('~/user-config.py')
 if os.path.exists(custom_path):
-    with open(custom_path, 'r') as f:
+    with open(custom_path, 'rb') as f:
         exec(compile(f.read(), custom_path, 'exec'), globals())
 
     del f


### PR DESCRIPTION
- Install via a separate script to reduce number of Docker
  Layers
- Do not install Pillow, since it requires a lot of packages