### PR TITLE
Include mwparserfromhell by default

### DIFF
--- a/singleuser/requirements.txt
+++ b/singleuser/requirements.txt
@@ -8,6 +8,7 @@ mwdiffs
 mwoauth
 mwtypes
 mwpersistence
+mwparserfromhell
 git+https://github.com/yuvipanda/python-wdqs.git
 
 # visualization libraries


### PR DESCRIPTION
When used within Pywikibot there seams to be no need to install it with `pip` but when using it as a standalone library I find myself installing it all the time. 