### PR TITLE
Userhome chown [Deploy will fail]

### DIFF
--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -107,7 +107,7 @@ jupyterhub:
       initContainers:
         - name: chown-userhome
           image: busybox
-          command: ['sh', '-c', 'chown 52771:52771 /home/paws']
+          command: ['chown', '-R', '52771:52771', '/home/paws']
           volumeMounts:
             - name: home
               mountPath: /home/paws

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -107,7 +107,7 @@ jupyterhub:
       initContainers:
         - name: chown-userhome
           image: busybox
-          command: ['chown', '-R', '52771:52771', '/home/paws']
+          command: ['chown', '52771:52771', '/home/paws']
           volumeMounts:
             - name: home
               mountPath: /home/paws

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -110,7 +110,9 @@ jupyterhub:
           command: ['sh', '-c', 'chown 52771:52771 /home/paws']
           volumeMounts:
             - name: home
-            mountPath: /home/paws
+              mountPath: /home/paws
+          securityContext: 
+            runAsUser: 0 
 
   ingress:
       enabled: true

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -104,6 +104,10 @@ jupyterhub:
           tag: v4db45b9
       storage:
           type: none
+      initContainers:
+        - name: chown-userhome
+          image: busybox
+          command: ['sh', '-c', 'chown 52771:52771 /home/paws']
 
   ingress:
       enabled: true

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -108,6 +108,9 @@ jupyterhub:
         - name: chown-userhome
           image: busybox
           command: ['sh', '-c', 'chown 52771:52771 /home/paws']
+          volumeMounts:
+            - name: home
+            mountPath: /home/paws
 
   ingress:
       enabled: true


### PR DESCRIPTION
This fixes https://phabricator.wikimedia.org/T188012 and obliviates the need for the root cronjob chowning userhomes.

At the moment autodeploy will fail, waiting on https://phabricator.wikimedia.org/T195217 to fix https://paws-deploy-hook.wmflabs.org since this is non-urgent. 