### PR TITLE
Hide clusters tab with CSS

### DIFF
--- a/images/singleuser/Dockerfile
+++ b/images/singleuser/Dockerfile
@@ -141,6 +141,11 @@ RUN pip install --no-cache-dir git+https://github.com/yuvipanda/nbpawspublic@023
 
 RUN pip install --no-cache-dir git+https://github.com/yuvipanda/ipynb-paws@60c94e3
 
+# use custom css to hide clusters tab
+COPY hide_clusters_tab.css /home/paws/.jupyter/custom/custom.css
+USER root
+RUN chown ${NB_USER}:${NB_USER} /home/paws/.jupyter/custom/custom.css
+
 USER ${NB_USER}
 
 EXPOSE 8888

--- a/images/singleuser/Dockerfile
+++ b/images/singleuser/Dockerfile
@@ -142,9 +142,7 @@ RUN pip install --no-cache-dir git+https://github.com/yuvipanda/nbpawspublic@023
 RUN pip install --no-cache-dir git+https://github.com/yuvipanda/ipynb-paws@60c94e3
 
 # use custom css to hide clusters tab
-COPY hide_clusters_tab.css /home/paws/.jupyter/custom/custom.css
-USER root
-RUN chown ${NB_USER}:${NB_USER} /home/paws/.jupyter/custom/custom.css
+COPY --chown=tools.paws:tools.paws hide_clusters_tab.css /home/paws/.jupyter/custom/custom.css
 
 USER ${NB_USER}
 

--- a/images/singleuser/hide_clusters_tab.css
+++ b/images/singleuser/hide_clusters_tab.css
@@ -1,0 +1,10 @@
+/*
+ * Placeholder for custom user CSS
+ * mainly to be overriden in profile/static/custom/custom.css
+ * This will always be an empty file in IPython
+ */
+
+/* Hide clusters tab */
+.nav > li > .clusters_tab_link {
+	display: none;
+}


### PR DESCRIPTION
See [T120629](https://phabricator.wikimedia.org/T120629) in Phabricator.

As @chicocvenancio said in the Phabricator task mentioned above, the CSS snippet written by @framawiki is simpler and more specific than the suggested in #22.