### PR TITLE
Update pywikibot from last stable release

### DIFF
--- a/images/singleuser/Dockerfile
+++ b/images/singleuser/Dockerfile
@@ -121,7 +121,7 @@ USER ${NB_USER}
 RUN pip --no-cache-dir install -r /tmp/requirements.txt
 
 # Install pywikibot
-RUN git clone --recursive https://gerrit.wikimedia.org/r/pywikibot/core.git /srv/paws/pwb
+RUN git clone --branch stable --recursive https://gerrit.wikimedia.org/r/pywikibot/core.git /srv/paws/pwb
 COPY --chown=tools.paws:tools.paws user-config.py /srv/paws/
 COPY --chown=tools.paws:tools.paws user-fixes.py /srv/paws/
 


### PR DESCRIPTION
A new "stable" tag was introduced which indicates a stable release of
pywikibot whereas master branch is under perpetual development and may
fail in some circumstanced during developing. This tag is updated
monthly when the tests passed or ealier if necessary e.g. upstream
changes.

The more stable release should be used for PAWS.

Bug: T217908